### PR TITLE
Customize top menu colors

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -1,4 +1,4 @@
 export const PLUGIN_ID = 'bitergiaAnalytics';
 export const PLUGIN_NAME = 'bitergia_analytics';
 
-export const API_PREFIX = '/api/kibiter';
+export const API_PREFIX = '/api/dashboards';

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -2,6 +2,7 @@
   "id": "bitergiaAnalytics",
   "version": "0.0.1",
   "opensearchDashboardsVersion": "opensearchDashboards",
+  "configPath": ["bitergia_analytics"],
   "requiredPlugins": ["navigation", "data"],
   "optionalPlugins": ["share"],
   "server": true,

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "bitergiaAnalytics",
   "version": "0.0.1",
-  "kibanaVersion": "7.10.0",
+  "opensearchDashboardsVersion": "opensearchDashboards",
   "requiredPlugins": ["navigation", "data"],
   "optionalPlugins": ["share"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -4,13 +4,8 @@
   "description": "Bitergia Analytics Plugin",
   "license": "Apache-2.0",
   "main": "index.js",
-  "kibana": {
-    "version": "7.10.0",
-    "templateVersion": "1.0.0"
-  },
   "scripts": {
-    "kbn": "node ../../scripts/kbn",
-    "es": "node ../../scripts/es",
+    "osd": "node ../../scripts/osd",
     "lint": "eslint .",
     "start": "yarn plugin_helpers start",
     "build": "yarn plugin_helpers build",

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -17,16 +17,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppMountParameters, CoreStart } from '../../../src/core/public';
 import { AppPluginStartDependencies } from './types';
-import {
-  EuiPage,
-  EuiPageBody,
-  EuiPageContent,
-  EuiPageContentHeader,
-  EuiPageContentHeaderSection,
-  EuiPageHeader,
-  EuiPageHeaderSection,
-  EuiTitle,
-} from '@elastic/eui';
 
 export const renderApp = (
   { notifications, http, chrome }: CoreStart,
@@ -34,29 +24,6 @@ export const renderApp = (
   { appBasePath, element }: AppMountParameters
 ) => {
   window.location.replace(window.location.href.split("app/")[0] + "app/dashboards#/view/Overview")
-  // ReactDOM.render(
-  //   <EuiPage>
-  //   <EuiPageBody component="div">
-  //     <EuiPageHeader>
-  //       <EuiPageHeaderSection>
-  //         <EuiTitle size="l">
-  //           <h1>Kibiter custom Menu</h1>
-  //         </EuiTitle>
-  //       </EuiPageHeaderSection>
-  //     </EuiPageHeader>
-  //     <EuiPageContent>
-  //       <EuiPageContentHeader>
-  //         <EuiPageContentHeaderSection>
-  //           <EuiTitle>
-  //             <h2>For seeing the menu at the top, please go to a dashboard page.</h2>
-  //           </EuiTitle>
-  //         </EuiPageContentHeaderSection>
-  //       </EuiPageContentHeader>
-  //     </EuiPageContent>
-  //   </EuiPageBody>
-  // </EuiPage>,
-  //   element
-  // );
 
   return () => ReactDOM.unmountComponentAtNode(element);
 };

--- a/public/components/kibiter_menu/kibiter_menu.js
+++ b/public/components/kibiter_menu/kibiter_menu.js
@@ -20,7 +20,7 @@ import './kibiter_menu_style.scss';
 
 async function getProjectName() {
   const url = window.location.href.split("/app/")
-  const response = await fetch(url[0] + '/api/kibiter/getprojectname', {
+  const response = await fetch(url[0] + '/api/dashboards/getprojectname', {
     method: 'GET',
     referrerPolicy: 'strict-origin-when-cross-origin',
     mode: 'cors',
@@ -32,7 +32,7 @@ async function getProjectName() {
 
 async function getMetadashboard() {
   const url = window.location.href.split("/app/")
-  const response = await fetch(url[0] + '/api/kibiter/getmetadashboard', {
+  const response = await fetch(url[0] + '/api/dashboards/getmetadashboard', {
     method: 'GET',
     referrerPolicy: 'strict-origin-when-cross-origin',
     mode: 'cors',
@@ -108,7 +108,13 @@ function changeBranding() {
   if (elasticChangeBranding && elasticChangeBranding.length && elasticChangeBranding[0].getAttribute("id") !== "bitergiaAnalyticsLogo") {
     elasticChangeBranding[0].innerHTML = bitergiaSVGLogo
     elasticChangeBranding[0].setAttribute("id", "bitergiaAnalyticsLogo")
-    document.querySelectorAll(".euiHeaderLogo__text")[0].innerHTML = "Bitergia Analytics"
+    elasticChangeBranding[0].setAttribute("viewBox", "0 0 32 32")
+    elasticChangeBranding[0].setAttribute("width", "32")
+    elasticChangeBranding[0].setAttribute("height", "32")
+    const text = document.createElement("span")
+    document.querySelector(".euiHeaderLogo").appendChild(text)
+    text.classList.add("euiHeaderLogo__text")
+    text.innerHTML = "Bitergia Analytics"
   }
   //Exit FS button
   const elasticFSChangeBranding = document.querySelectorAll(
@@ -134,7 +140,7 @@ async function locationHashChanged() {
 
     //Then add the navbar
     const navBarMenu = document.querySelectorAll(
-      '.application'
+      '#globalHeaderBars'
     )
 
     if (navBarMenu && navBarMenu.length) {
@@ -148,8 +154,9 @@ async function locationHashChanged() {
         }
         const kibiterJSMenuItem = document.createElement('div');
         kibiterJSMenuItem.setAttribute("id", "kibiterjsmenu");
+        kibiterJSMenuItem.classList.add("euiHeader--fixed")
         kibiterJSMenuItem.innerHTML = getKibiterJSMenu($, projectname.data.projectname.name, metadashboard.data.metadashboard, columns, currentDashboard);
-        navBarMenu[0].insertBefore(kibiterJSMenuItem, navBarMenu[0].firstChild)
+        navBarMenu[0].insertBefore(kibiterJSMenuItem, navBarMenu[0].lastChild)
 
         // Redirect to overview when clicking on project name
         $('#kibiterProjectName').click(function () {

--- a/public/components/kibiter_menu/kibiter_menu.js
+++ b/public/components/kibiter_menu/kibiter_menu.js
@@ -100,45 +100,25 @@ function chunkify(a, n, balanced) {
   return out;
 }
 
-function changeBranding() {
-  // Branding
-  const elasticChangeBranding = document.querySelectorAll(
-    '.euiHeaderLogo svg'
-  )
-  if (elasticChangeBranding && elasticChangeBranding.length && elasticChangeBranding[0].getAttribute("id") !== "bitergiaAnalyticsLogo") {
-    elasticChangeBranding[0].innerHTML = bitergiaSVGLogo
-    elasticChangeBranding[0].setAttribute("id", "bitergiaAnalyticsLogo")
-    elasticChangeBranding[0].setAttribute("viewBox", "0 0 32 32")
-    elasticChangeBranding[0].setAttribute("width", "32")
-    elasticChangeBranding[0].setAttribute("height", "32")
-    const text = document.createElement("span")
-    document.querySelector(".euiHeaderLogo").appendChild(text)
-    text.classList.add("euiHeaderLogo__text")
-    text.innerHTML = "Bitergia Analytics"
-  }
-  //Exit FS button
-  const elasticFSChangeBranding = document.querySelectorAll(
-    '.dshExitFullScreenButton svg'
-  )
-  if (elasticFSChangeBranding && elasticFSChangeBranding.length && elasticFSChangeBranding[0].getAttribute("id") !== "bitergiaAnalyticsFSLogo") {
-    elasticFSChangeBranding[0].innerHTML = bitergiaSVGLogo
-    elasticFSChangeBranding[0].setAttribute("id", "bitergiaAnalyticsFSLogo")
+function changeBranding(branding) {
+  if (Object.keys(branding).length !== 0) {
+    document.body.style.setProperty("--background-color", branding.backgroundColor);
+    document.body.style.setProperty("--text-color", branding.textColor);
+    document.body.style.setProperty("--menu-item-color", branding.menuItemColor);
+    document.body.style.setProperty("--link-color", branding.linkColor);
+    document.body.style.setProperty("--selected-item-color", branding.selectedItemColor);
   }
 }
 
 async function locationHashChanged() {
-
-  const url = window.location.href.split("/app/")
+  const url = window.location.href.split("/app/");
+  const columns = 4;
   const projectname = await getProjectName()
   const metadashboard = await getMetadashboard()
   const currentDashboard = getCurrentDashboard(metadashboard.data.metadashboard)
-  const columns = 4;
 
   const observer = new MutationObserver(async function (mutations) {
-    // First change branding if needed
-    changeBranding()
-
-    //Then add the navbar
+    // Add the navbar
     const navBarMenu = document.querySelectorAll(
       '#globalHeaderBars'
     )
@@ -187,7 +167,6 @@ async function locationHashChanged() {
                   }
                 }
               }
-              console.log(item)
             }
           });
 
@@ -208,7 +187,6 @@ async function locationHashChanged() {
               });
             })
           }
-
         });
       } catch (e) {
         return e
@@ -238,28 +216,32 @@ async function locationHashChanged() {
 }
 
 
-// Catch all the possibilities of moving between the app
-history.pushState = (f => function pushState() {
-  var ret = f.apply(this, arguments);
-  window.dispatchEvent(new Event('pushstate'));
-  window.dispatchEvent(new Event('locationchange'));
-  return ret;
-})(history.pushState);
+export function init(config) {
+  // Change branding
+  changeBranding(config.branding);
 
-history.replaceState = (f => function replaceState() {
-  var ret = f.apply(this, arguments);
-  window.dispatchEvent(new Event('replacestate'));
-  window.dispatchEvent(new Event('locationchange'));
-  return ret;
-})(history.replaceState);
+  // Catch all the possibilities of moving between the app
+  history.pushState = (f => function pushState() {
+    var ret = f.apply(this, arguments);
+    window.dispatchEvent(new Event('pushstate'));
+    window.dispatchEvent(new Event('locationchange'));
+    return ret;
+  })(history.pushState);
 
-window.addEventListener('popstate', () => {
-  window.dispatchEvent(new Event('locationchange'))
-});
+  history.replaceState = (f => function replaceState() {
+    var ret = f.apply(this, arguments);
+    window.dispatchEvent(new Event('replacestate'));
+    window.dispatchEvent(new Event('locationchange'));
+    return ret;
+  })(history.replaceState);
 
-window.addEventListener('locationchange', function () {
+  window.addEventListener('popstate', () => {
+    window.dispatchEvent(new Event('locationchange'))
+  });
+
+  window.addEventListener('locationchange', function () {
+    locationHashChanged();
+  })
+
   locationHashChanged();
-})
-
-
-locationHashChanged();
+}

--- a/public/components/kibiter_menu/kibiter_menu_style.scss
+++ b/public/components/kibiter_menu/kibiter_menu_style.scss
@@ -1,27 +1,35 @@
+:root {
+  --background-color: #333;
+  --text-color: #cecece;
+  --link-color: #fcb42e;
+  --menu-item-color: #dedede;
+  --selected-item-color: #f49e42;
+}
+
+.euiHeader--dark {
+  background-color: var(--background-color);
+  border-bottom-color: var(--background-color);
+}
+
 .kibiterLocalNav {
-    background-color: #333;
-    height: 40px;
+    background-color: var(--background-color);
+    height: 41px;
     padding-left: 6px;
 }
 
 .kuiLocalBreadcrumbs {
-    background-color: #333 !important;
+    background-color: var(--background-color);
     border: none;
 }
 
 .kibiterLocalDropdownTitle{
-    color: #cecece !important;
+    color: var(--text-color);
     font-size: 20px !important;
     margin-bottom: 5px !important;
 }
 
 .kibiterLocalDropdownText{
-    color: #cecece !important;
-}
-
-.kibiterLocalMenuItem:hover, .kibiterLocalMenuItem:focus {
-    background-color: #000000 !important;
-    color: #F5F5F5 !important;
+    color: var(--text-color);
 }
 
 .kibiterLocalMenuItem::-moz-focus-inner {
@@ -29,15 +37,14 @@
 }
 
 .kibiterLocalDropdown {
-    background-color: #525252 !important;
-    z-index: 3000 !important;
+    background-color: var(--background-color);
+    z-index: 4000 !important;
     position: fixed !important;
     top: 89px;
     width: 100%;
     height: 140px;
+    color: var(--link-color);
 }
-
-
 
 .kuiLocalMenu {
     padding: 0px !important;
@@ -48,7 +55,7 @@
     color: #ffffff;
 }
 .theme-dark .kuiLocalMenuItem {
-    color: #dedede;
+    color: var(--menu-item-color);
 }
 .kuiLocalMenuItem:hover, .kuiLocalMenuItem:focus {
     background-color: #006BB4;
@@ -80,20 +87,20 @@
 }
 
 .selected-kibiter-item {
-    background-color: #f49e42 !important;
-    color: #FFF !important;
+    background-color: var(--selected-item-color);
+    color: var(--menu-item-color) !important;
 }
 
 .projectName {
-    color: rgb(252, 180, 46) !important;
+    color: var(--link-color);
     padding-right: 20px;
 }
 .projectName:hover {
-    color: rgb(255, 200, 98) !important;
+    color: var(--link-color);
 }
 
 .submenuitem {
-    color: rgb(252, 180, 46) !important;
+  color: currentColor !important;
 }
 
 #kibiterjsmenu {

--- a/public/components/kibiter_menu/kibiter_menu_style.scss
+++ b/public/components/kibiter_menu/kibiter_menu_style.scss
@@ -1,6 +1,7 @@
 .kibiterLocalNav {
     background-color: #333;
     height: 40px;
+    padding-left: 6px;
 }
 
 .kuiLocalBreadcrumbs {
@@ -31,7 +32,7 @@
     background-color: #525252 !important;
     z-index: 3000 !important;
     position: fixed !important;
-    top: 137px;
+    top: 89px;
     width: 100%;
     height: 140px;
 }
@@ -93,4 +94,25 @@
 
 .submenuitem {
     color: rgb(252, 180, 46) !important;
-} 
+}
+
+#kibiterjsmenu {
+  z-index: 2600;
+}
+
+.euiHeader--fixed + .euiHeader--fixed + .euiHeader--fixed {
+  top: 90px;
+}
+
+.euiBody--headerIsFixed {
+  padding-top: 138px !important;
+}
+
+.euiBody--headerIsFixed .euiFlyout, .euiBody--headerIsFixed .euiCollapsibleNav {
+  top: 140px !important;
+  height: calc(100% - 140px) !important;
+}
+
+.app-wrapper {
+  min-height: calc(100vh - 138px) !important;
+}

--- a/public/index.ts
+++ b/public/index.ts
@@ -16,9 +16,10 @@
 import './index.scss';
 
 import { BitergiaAnalyticsPlugin } from './plugin';
+import { PluginInitializerContext } from '../../../src/core/public';
 
 // This exports static code and TypeScript types,
 // as well as, Kibana Platform `plugin()` initializer.
-export function plugin() {
-  return new BitergiaAnalyticsPlugin();
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new BitergiaAnalyticsPlugin(initializerContext);
 }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -17,17 +17,25 @@ import {
   AppMountParameters,
   CoreSetup,
   CoreStart,
+  PluginInitializerContext,
 } from '../../../src/core/public';
 import {
   AppPluginStartDependencies,
 } from './types';
 import './components/kibiter_menu/kibiter_menu';
+import { init } from './components/kibiter_menu/kibiter_menu';
 import { PLUGIN_NAME } from '../common';
 import { i18n } from '@osd/i18n';
 
 export class BitergiaAnalyticsPlugin
   implements Plugin<BitergiaAnalyticsPluginSetup, BitergiaAnalyticsPluginStart> {
+  // @ts-ignore : initializerContext not used
+  constructor(private readonly initializerContext: PluginInitializerContext) {}
   public setup(core: CoreSetup): BitergiaAnalyticsPluginSetup {
+    // Get branding from opensearch_dashboards.yml and initialize plugin
+    const config = this.initializerContext.config.get();
+    init(config);
+
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_NAME,
@@ -39,7 +47,7 @@ export class BitergiaAnalyticsPlugin
         // Get start services as specified in opensearch_dashboards.json
         const [coreStart, depsStart] = await core.getStartServices();
         // Render the application
-        return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
+        return renderApp(coreStart, depsStart as AppPluginStartDependencies, params, config);
       },
     });
 
@@ -47,7 +55,7 @@ export class BitergiaAnalyticsPlugin
     return {};
   }
 
-  public start(core: CoreStart): BitergiaAnalyticsPluginStart {
+  public async start(core: CoreStart): BitergiaAnalyticsPluginStart {
     return {};
   }
 

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -23,34 +23,23 @@ import {
 } from './types';
 import './components/kibiter_menu/kibiter_menu';
 import { PLUGIN_NAME } from '../common';
-import { i18n } from '@kbn/i18n';
+import { i18n } from '@osd/i18n';
 
 export class BitergiaAnalyticsPlugin
-{
-  public setup(core: CoreSetup) {
+  implements Plugin<BitergiaAnalyticsPluginSetup, BitergiaAnalyticsPluginStart> {
+  public setup(core: CoreSetup): BitergiaAnalyticsPluginSetup {
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_NAME,
       title: 'Bitergia Analytics',
-      category: {
-        id: 'kibana',
-        label: i18n.translate('core.ui.kibanaNavList.label', {
-          defaultMessage: 'Kibana',
-        }),
-        euiIconType: 'logoKibana',
-        order: 1000,
-      },
+      updater$: this.appUpdater,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');
-        // Get start services as specified in kibana.json
+        // Get start services as specified in opensearch_dashboards.json
         const [coreStart, depsStart] = await core.getStartServices();
         // Render the application
-        return renderApp(
-          coreStart,
-          depsStart as AppPluginStartDependencies,
-          params
-        );
+        return renderApp(coreStart, depsStart as AppPluginStartDependencies, params);
       },
     });
 
@@ -58,7 +47,7 @@ export class BitergiaAnalyticsPlugin
     return {};
   }
 
-  public start(core: CoreStart) {
+  public start(core: CoreStart): BitergiaAnalyticsPluginStart {
     return {};
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,11 +13,27 @@
  * permissions and limitations under the License.
  */
 
+import { schema } from '@osd/config-schema';
 import { PluginInitializerContext } from '../../../src/core/server';
 import { BitergiaAnalyticsPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
 // as well as, OpenSearch Dashboards Platform `plugin()` initializer.
+
+export const config = {
+  exposeToBrowser: {
+    branding: true
+  },
+  schema: schema.object({
+    branding: schema.object({
+      backgroundColor: schema.string({ defaultValue: '#333' }),
+      textColor: schema.string({ defaultValue: '#cecece' }),
+      menuItemColor: schema.string({ defaultValue: '#dedede' }),
+      linkColor: schema.string({ defaultValue: '#fcb42e' }),
+      selectedItemColor: schema.string({ defaultValue: '#f49e42' }),
+    }),
+  })
+};
 
 export function plugin(initializerContext: PluginInitializerContext) {
   return new BitergiaAnalyticsPlugin(initializerContext);

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,9 +16,14 @@
 import { PluginInitializerContext } from '../../../src/core/server';
 import { BitergiaAnalyticsPlugin } from './plugin';
 
-//  This exports static code and TypeScript types,
-//  as well as, Kibana Platform `plugin()` initializer.
+// This exports static code and TypeScript types,
+// as well as, OpenSearch Dashboards Platform `plugin()` initializer.
 
 export function plugin(initializerContext: PluginInitializerContext) {
   return new BitergiaAnalyticsPlugin(initializerContext);
 }
+
+export {
+  BitergiaAnalyticsPluginSetup,
+  BitergiaAnalyticsPluginStart
+} from './types';

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -18,23 +18,15 @@ import {
   CoreSetup,
   CoreStart,
   Logger,
-  ILegacyClusterClient,
 } from '../../../src/core/server';
-import registerRoutes from './routes';
-
-export interface BitergiaAnalyticsPluginRequestContext {
-  logger: Logger;
-  esClient: ILegacyClusterClient;
-}
-//@ts-ignore
-declare module 'kibana/server' {
-  interface RequestHandlerContext {
-    bitergia_analytics_plugin: BitergiaAnalyticsPluginRequestContext;
-  }
-}
+import {
+  BitergiaAnalyticsPluginSetup,
+  BitergiaAnalyticsPluginStart
+} from './types';
+import { defineRoutes } from './routes';
 
 export class BitergiaAnalyticsPlugin
-{
+  implements Plugin<BitergiaAnalyticsPluginSetup, BitergiaAnalyticsPluginStart> {
   private readonly logger: Logger;
 
   constructor(initializerContext: PluginInitializerContext) {
@@ -42,17 +34,17 @@ export class BitergiaAnalyticsPlugin
   }
 
   public setup(core: CoreSetup) {
+    this.logger.debug('bitergia_analytics: Setup');
     const router = core.http.createRouter();
 
     // Register server side APIs
-    registerRoutes(router);
+    defineRoutes(router);
 
     return {};
   }
 
   public start(core: CoreStart) {
     this.logger.debug('bitergia analytics plugin starting');
-
     return {};
   }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,6 +16,6 @@
 import registerKibiterMenuRetrieveRoute from './menu';
 import { IRouter } from '../../../../src/core/server';
 
-export default function (router: IRouter) {
+export function defineRoutes(router: IRouter) {
   registerKibiterMenuRetrieveRoute(router);
 }

--- a/server/routes/menu.ts
+++ b/server/routes/menu.ts
@@ -15,13 +15,13 @@
 
 import {
   IRouter,
-  IKibanaResponse,
+  OpenSearchDashboardsResponse,
   ResponseError
 } from '../../../../src/core/server';
 import { API_PREFIX } from '../../common';
 
 export default function (router: IRouter) {
-  
+
   //get project name
   router.get(
     {
@@ -32,9 +32,9 @@ export default function (router: IRouter) {
       context,
       request,
       response
-    ): Promise<IKibanaResponse<any | ResponseError>> => {
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
       try {
-        const esResp = await context.core.elasticsearch.legacy.client.callAsCurrentUser(
+        const esResp = await context.core.opensearch.legacy.client.callAsCurrentUser(
           'get',
           {
             index: ".kibana",
@@ -76,9 +76,9 @@ export default function (router: IRouter) {
       context,
       request,
       response
-    ): Promise<IKibanaResponse<any | ResponseError>> => {
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
       try {
-        const esResp = await context.core.elasticsearch.legacy.client.callAsCurrentUser(
+        const esResp = await context.core.opensearch.legacy.client.callAsCurrentUser(
           'get',
           {
             index: ".kibana",

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface BitergiaAnalyticsPluginSetup {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface BitergiaAnalyticsPluginStart {}


### PR DESCRIPTION
This PR adds the possibility to customize the Bitergia top menu colors on OpenSearch Dashboards versions 1.1.0 - 1.2.0.
You can configure the colors on the `opensearch_dashboards.yml` file, under `bitergia_analytics.branding`. For example:

```yaml
bitergia_analytics.branding:
  backgroundColor: "#F13333"
  textColor: "#FFFFFF"
  linkColor: "#FFFFFF"
  menuItemColor: "#FFFFFF"
  selectedItemColor: "#C00000"
```

On OpenSearch 1.2.0 the logos can be customized on `opensearch_dashboards.yml` too, so I removed the code that replaced them. 

To test it, you can run OpenSearch Dashboards on a [development environment](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/DEVELOPER_GUIDE.md#getting-started) and install the plugin or use Docker.

Example `Dockerfile`:
```dockerfile
FROM opensearchproject/opensearch-dashboards:1.2.0
ADD ./bitergiaAnalytics-1.2.0.zip /usr/
RUN /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install file:///usr/bitergiaAnalytics-1.2.0.zip
COPY ./opensearch_dashboards.yml /usr/share/opensearch-dashboards/config/
```
Distributable zip built with `yarn build`: [bitergiaAnalytics-1.2.0.zip](https://github.com/Bitergia/bitergia-analytics-plugin/files/7619289/bitergiaAnalytics-1.2.0.zip)

Example YAML file:
```yaml
server.host: "0"
opensearch.hosts: ["https://localhost:9200"]
opensearch.ssl.verificationMode: none
opensearch.username: "kibanaserver"
opensearch.password: "kibanaserver"
opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]
# Use this setting if you are running opensearch-dashboards without https
opensearch_security.cookie.secure: false

bitergia_analytics.branding:
  backgroundColor: "#f13333"
  textColor: "#FFFFFF"
  linkColor: "#FFFFFF"
  menuItemColor: "#FFFFFF"
  selectedItemColor: "#c00000"

# Customize logos and title on Opensearch 1.2.0
opensearchDashboards.branding:
  mark:
    defaultUrl: "https://bitergia.com/assets/img/bitergia.png"
  applicationTitle: "Bitergia Analytics"
```
Example `docker-compose.yml`:
```yaml
version: '3'
services:
  opensearch-node1:
    image: opensearchproject/opensearch:1.2.0
    container_name: opensearch-node1
    environment:
      - discovery.type=single-node
      - node.name=opensearch-node1
      - bootstrap.memory_lock=true
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
      - network.host=0.0.0.0
    ulimits:
      memlock:
        soft: -1
        hard: -1
      nofile:
        soft: 65536
        hard: 65536
    ports:
      - 9200:9200
      - 9600:9600
    networks:
      - opensearch-net
  opensearch-dashboards:
    image: opensearch-with-plugin
    container_name: opensearch-dashboards
    ports:
      - 5601:5601
    expose:
      - "5601"
    environment:
      OPENSEARCH_HOSTS: '["https://opensearch-node1:9200"]'
    networks:
      - opensearch-net

volumes:
  opensearch-data1:

networks:
  opensearch-net:
```