### PR TITLE
Improve fullscreen observer to reduce load times

### DIFF
--- a/public/components/kibiter_menu/kibiter_menu.js
+++ b/public/components/kibiter_menu/kibiter_menu.js
@@ -220,21 +220,13 @@ async function locationHashChanged() {
 
 
   // Observer for the logos (when entering/exiting Full Screen)
-  let fullScreenObserverEntity = document.getElementById("kibana-body");
+  // TODO: Remove observer in OpenSearch 1.2.0
+  let fullScreenObserverEntity = document.querySelector(".app-wrapper");
   let config = {
     attributes: true,
-    childList: true,
-    subtree: true
+    attributeFilter: ["class"]
   };
-  // Callback function to execute when mutations are observed, when the elements appear
-  let callback = function (mutationsList) {
-    for (let mutation of mutationsList) {
-      if (mutation.type == 'childList') {
-        changeBranding()
-      }
-    }
-  };
-  let fsObserver = new MutationObserver(callback);
+  let fsObserver = new MutationObserver(changeBranding);
   fsObserver.observe(fullScreenObserverEntity, config);
 }
 


### PR DESCRIPTION
This PR changes the observer used to replace the logos on fullscreen mode to only listen for the `class` attribute mutation on `app-wrapper`, which is triggered when entering or exiting the mode. This will avoid looping through other mutations and running `changeBranding` when it's not needed and improve load times.