### PR TITLE
Get base URL for links from dashboards app

### DIFF
--- a/public/components/dropdown.tsx
+++ b/public/components/dropdown.tsx
@@ -21,7 +21,7 @@ import {
   EuiListGroup,
 } from '@elastic/eui';
 
-export const Dropdown = ({ item }) => {
+export const Dropdown = ({ item, baseURL }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dashboards = getDashboardLinks(item.dashboards);
 
@@ -29,7 +29,7 @@ export const Dropdown = ({ item }) => {
     return links.map((dashboard) => {
       return {
         label: dashboard.name,
-        href: `dashboards#/view/${dashboard.panel_id}`,
+        href: `${baseURL}#/view/${dashboard.panel_id}`,
       };
     });
   }

--- a/public/components/link.tsx
+++ b/public/components/link.tsx
@@ -16,10 +16,10 @@
 import React from 'react';
 import { EuiHeaderLink } from '@elastic/eui';
 
-export const Link = ({ item }) => {
+export const Link = ({ item, baseURL }) => {
   return (
     <EuiHeaderLink
-      href={`dashboards#/view/${item.panel_id}`}
+      href={`${baseURL}#/view/${item.panel_id}`}
       isActive={item.isActive}
     >
       {item.name}

--- a/public/components/menu.tsx
+++ b/public/components/menu.tsx
@@ -20,13 +20,14 @@ import { Dropdown } from './dropdown.tsx';
 
 export const Menu = (props) => {
   const [metadashboard, setMetadashboard] = useState(props.metadashboard);
+  const { baseURL } = props
 
   function setActiveLink() {
     let updated = metadashboard;
 
-    if (props.history.location.hash.includes('#/view/')) {
+    if (props.history.location.hash.includes(`${baseURL}#/view/`)) {
       const currentDashboard = props.history.location.hash
-        .split('#/view/')[1]
+        .split(`${baseURL}#/view/`)[1]
         .split('?')[0];
 
       updated = metadashboard.map((dashboard) => {
@@ -70,9 +71,9 @@ export const Menu = (props) => {
     <EuiHeaderLinks gutterSize="xs" className="bitergia-menu">
       {metadashboard.map((link, index) =>
         link.type === 'entry' ? (
-          <Link item={link} key={index} />
+          <Link item={link} baseURL={baseURL} key={index} />
         ) : (
-          <Dropdown item={link} key={index} />
+          <Dropdown item={link} baseURL={baseURL} key={index} />
         )
       )}
     </EuiHeaderLinks>

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -62,9 +62,11 @@ export class BitergiaAnalyticsPlugin
     // Get branding from opensearch_dashboards.yml
     const { branding } = this.initializerContext.config.get();
 
+    const baseURL = core.application.getUrlForApp('dashboards');
+
     // Add project name to header
     core.chrome.navControls.registerCenter({
-      mount: (target) => this.mountProjectName(branding.projectName, target),
+      mount: (target) => this.mountProjectName(branding.projectName, baseURL, target),
       order: 1,
     });
 
@@ -76,7 +78,7 @@ export class BitergiaAnalyticsPlugin
       const metadashboard = response.data.metadashboard;
       core.chrome.navControls.registerCenter({
         order: 2,
-        mount: (target) => this.mountMenu(metadashboard, target),
+        mount: (target) => this.mountMenu(metadashboard, baseURL, target),
       });
     } catch (error) {
       console.log(error);
@@ -89,21 +91,21 @@ export class BitergiaAnalyticsPlugin
 
   public stop() {}
 
-  private mountMenu(metadashboard, targetDomElement) {
+  private mountMenu(metadashboard, baseURL, targetDomElement) {
     // Initialize router history to know which route is active
     const history = createBrowserHistory();
 
     ReactDOM.render(
-      <Menu metadashboard={metadashboard} history={history} />,
+      <Menu metadashboard={metadashboard} baseURL={baseURL} history={history} />,
       targetDomElement
     );
     return () => ReactDOM.unmountComponentAtNode(targetDomElement);
   }
 
-  private mountProjectName(name, targetDomElement) {
+  private mountProjectName(name, baseURL, targetDomElement) {
     ReactDOM.render(
       <EuiHeaderLink
-        href="dashboards#/view/Overview"
+        href={`${baseURL}#/view/Overview`}
         color="ghost"
         className="project-link"
       >


### PR DESCRIPTION
Builds the menu links using the `dashboards` app URL as base. This avoids conflicts with with other app URLs, e.g. index patterns manager.