### PR TITLE
Add branding setting for menu items on hover

### DIFF
--- a/public/index.scss
+++ b/public/index.scss
@@ -3,6 +3,7 @@
   --text-color: #cecece;
   --link-color: #fcb42e;
   --menu-item-color: #dedede;
+  --menu-item-color--hover: #000000;
   --selected-item-color: #f49e42;
   --dropdown-color: #525252;
 }
@@ -31,7 +32,7 @@
 }
 
 .euiHeader--dark .euiHeaderLink:not(.project-link):hover {
-  background-color: #000000;
+  background-color: var(--menu-item-color--hover);
 }
 
 .bitergia-menu-parent {
@@ -40,7 +41,7 @@
 }
 
 .euiHeader--dark .project-link {
-  color: #FFFFFF;
+  color: #ffffff;
   font-size: 1.25rem;
   letter-spacing: -0.025em;
   font-weight: 300;

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -66,7 +66,8 @@ export class BitergiaAnalyticsPlugin
 
     // Add project name to header
     core.chrome.navControls.registerCenter({
-      mount: (target) => this.mountProjectName(branding.projectName, baseURL, target),
+      mount: (target) =>
+        this.mountProjectName(branding.projectName, baseURL, target),
       order: 1,
     });
 
@@ -96,7 +97,11 @@ export class BitergiaAnalyticsPlugin
     const history = createBrowserHistory();
 
     ReactDOM.render(
-      <Menu metadashboard={metadashboard} baseURL={baseURL} history={history} />,
+      <Menu
+        metadashboard={metadashboard}
+        baseURL={baseURL}
+        history={history}
+      />,
       targetDomElement
     );
     return () => ReactDOM.unmountComponentAtNode(targetDomElement);
@@ -126,6 +131,10 @@ export class BitergiaAnalyticsPlugin
       document.body.style.setProperty(
         '--menu-item-color',
         branding.menuItemColor
+      );
+      document.body.style.setProperty(
+        '--menu-item-color--hover',
+        branding.menuItemHoverColor
       );
       document.body.style.setProperty('--link-color', branding.linkColor);
       document.body.style.setProperty(

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,6 +30,7 @@ export const config = {
       backgroundColor: schema.string({ defaultValue: '#333' }),
       textColor: schema.string({ defaultValue: '#cecece' }),
       menuItemColor: schema.string({ defaultValue: '#dedede' }),
+      menuItemHoverColor: schema.string({ defaultValue: '#000000' }),
       linkColor: schema.string({ defaultValue: '#fcb42e' }),
       selectedItemColor: schema.string({ defaultValue: '#f49e42' }),
       dropdownColor: schema.string({ defaultValue: '#525252' }),


### PR DESCRIPTION
Adds a new setting to customize the background color of the menu items on mouseover.

```yml
bitergia_analytics.branding:
  menuItemHoverColor: 'red'
```
![imagen](https://user-images.githubusercontent.com/26812577/165965478-92d554ba-ad63-41a0-aee7-b96756a9fe0e.png)
