### PR TITLE
Add compatibility with OpenSearch Dashboards 1.3.2

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "bitergiaAnalytics",
-  "version": "0.0.7",
-  "opensearchDashboardsVersion": "1.2.0",
+  "version": "0.0.8-dev",
+  "opensearchDashboardsVersion": "1.3.2",
   "configPath": ["bitergia_analytics"],
   "requiredPlugins": ["navigation", "data", "opensearchDashboardsReact"],
   "optionalPlugins": ["share"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitergia_analytics",
-  "version": "0.0.7",
+  "version": "0.0.8-dev",
   "description": "Bitergia Analytics Plugin",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
This commit bumps the version of the OpenSearch Dashboards dependency to 1.3.2, making it compatible.
