### PR TITLE
API to import/export menu

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -1,0 +1,63 @@
+name: functional testing
+
+on: [push, pull_request]
+
+env:
+  CI: 1
+  GCS_UPLOAD_PREFIX: fake
+  TEST_OPENSEARCH_DASHBOARDS_HOST: localhost
+  TEST_OPENSEARCH_DASHBOARDS_PORT: 6610
+  TEST_OPENSEARCH_TRANSPORT_PORT: 9403
+  TEST_OPENSEARCH_PORT: 9400
+  OSD_SNAPSHOT_SKIP_VERIFY_CHECKSUM: true
+
+jobs:
+  test:
+    name: Functional tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout plugin source code
+        uses: actions/checkout@v2
+        with:
+          path: bitergia-analytics-plugin
+      - name: Get plugin metadata
+        id: plugin_metadata
+        run: |
+          echo "::set-output name=name::$(node -p "(require('./bitergia-analytics-plugin/package.json').name)")"
+          echo "::set-output name=version::$(node -p "(require('./bitergia-analytics-plugin/package.json').version).match(/[.0-9]+/)[0]")"
+      - name: Get OpenSearch Dashboards version
+        id: osd_version
+        run: |
+          echo "::set-output name=version::$(node -p "(require('./bitergia-analytics-plugin/opensearch_dashboards.json').opensearchDashboardsVersion).match(/[.0-9]+/)[0]")"
+      - name: Checkout OpenSearch Dashboards
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: ${{ steps.osd_version.outputs.version }}
+          path: OpenSearch-Dashboards
+      - name: Get node and yarn versions
+        id: versions
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")"
+          echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.versions.outputs.node_version }}
+      - name: Setup yarn
+        run: |
+          npm uninstall -g yarn
+          echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
+          npm i -g yarn@${{ steps.versions.outputs.yarn_version }}
+      - name: Move plugin to OpenSearch Dashboards folder
+        run: |
+          mkdir -p OpenSearch-Dashboards/plugins
+          mv bitergia-analytics-plugin OpenSearch-Dashboards/plugins
+      - name: Bootstrap plugin/opensearch-dashboards
+        run: |
+          cd OpenSearch-Dashboards/plugins/bitergia-analytics-plugin
+          yarn osd bootstrap
+      - name: Run functional tests
+        run: |
+          cd ./OpenSearch-Dashboards/plugins/bitergia-analytics-plugin
+          yarn test:api

--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ Use the API to import and export the plugin's menu. You must use the `osd-xsrf:t
 Returns the menu data in a JSON format.
 
 ```
- GET /_plugins/_bap/metadashboard
+ GET /_plugins/_bap/menu
+```
+
+##### Sample request
+
+```
+curl -X GET <OSD URL>/_plugins/_bap/menu --header 'osd-xsrf: true' --user '<USERNAME>:<PASSWORD>'
 ```
 
 ### Update menu
@@ -94,18 +100,18 @@ Returns the menu data in a JSON format.
 Updates the menu data or creates one if it does not exist.
 
 ```
- PUT /_plugins/_bap/metadashboard
+ PUT /_plugins/_bap/menu
 ```
 
 ##### Sample request
 
 ```
-curl -X PUT <OSD URL>/_plugins/_bap/metadashboard \
+curl -X PUT <OSD URL>/_plugins/_bap/menu \
 --header 'osd-xsrf: true' \
 --user '<USERNAME>:<PASSWORD>' \
 --header 'Content-Type: application/json' \
 -d '{
-  "metadashboard": [
+  "menu": [
     {
       "name": "Overview",
       "dashboard_id": "Overview",

--- a/README.md
+++ b/README.md
@@ -77,6 +77,54 @@ folder the following command:
 yarn start
 ```
 
+## API
+
+Use the API to import and export the plugin's menu. You must use the `osd-xsrf:true` header for all API calls and `Content-Type: application/json` when you send a payload.
+
+### Get menu
+
+Returns the menu data in a JSON format.
+
+```
+ GET /_plugins/_bap/metadashboard
+```
+
+### Update menu
+
+Updates the menu data or creates one if it does not exist.
+
+```
+ PUT /_plugins/_bap/metadashboard
+```
+
+##### Sample request
+
+```
+curl -X PUT <OSD URL>/_plugins/_bap/metadashboard \
+--header 'osd-xsrf: true' \
+--user '<USERNAME>:<PASSWORD>' \
+--header 'Content-Type: application/json' \
+-d '{
+  "metadashboard": [
+    {
+      "name": "Overview",
+      "dashboard_id": "Overview",
+      "type": "entry"
+    },
+    {
+      "name": "About",
+      "type": "menu",
+      "dashboards": [
+        {
+          "name": "Contact",
+          "type": "entry",
+          "dashboard_id": "https://example.com"
+        }
+      ]
+    }
+  ]
+}'
+```
 
 ## License
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2021-2022 Bitergia
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -14,15 +15,15 @@
  * permissions and limitations under the License.
  */
 
-module.exports = {
-  presets: [
-    require('@babel/preset-env'),
-    require('@babel/preset-react'),
-    require('@babel/preset-typescript'),
-  ],
-  plugins: [
-    [require('@babel/plugin-transform-runtime'), { regenerator: true }],
-    require('@babel/plugin-proposal-class-properties'),
-    require('@babel/plugin-proposal-object-rest-spread'),
-  ],
-};
+ module.exports = {
+   presets: [
+     require('@babel/preset-env'),
+     require('@babel/preset-react'),
+     require('@babel/preset-typescript'),
+   ],
+   plugins: [
+     [require('@babel/plugin-transform-runtime'), { regenerator: true }],
+     require('@babel/plugin-proposal-class-properties'),
+     require('@babel/plugin-proposal-object-rest-spread'),
+   ],
+ };

--- a/babel.config.js
+++ b/babel.config.js
@@ -15,15 +15,15 @@
  * permissions and limitations under the License.
  */
 
- module.exports = {
-   presets: [
-     require('@babel/preset-env'),
-     require('@babel/preset-react'),
-     require('@babel/preset-typescript'),
-   ],
-   plugins: [
-     [require('@babel/plugin-transform-runtime'), { regenerator: true }],
-     require('@babel/plugin-proposal-class-properties'),
-     require('@babel/plugin-proposal-object-rest-spread'),
-   ],
- };
+module.exports = {
+  presets: [
+    require('@babel/preset-env'),
+    require('@babel/preset-react'),
+    require('@babel/preset-typescript'),
+  ],
+  plugins: [
+    [require('@babel/plugin-transform-runtime'), { regenerator: true }],
+    require('@babel/plugin-proposal-class-properties'),
+    require('@babel/plugin-proposal-object-rest-spread'),
+  ],
+};

--- a/common/index.ts
+++ b/common/index.ts
@@ -16,4 +16,4 @@
 export const PLUGIN_ID = 'bitergiaAnalytics';
 export const PLUGIN_NAME = 'bitergia_analytics';
 
-export const API_PREFIX = '/api/dashboards';
+export const API_PREFIX = '/_plugins/_bap';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "yarn plugin_helpers start",
     "build": "yarn plugin_helpers build",
     "plugin_helpers": "node ../../scripts/plugin_helpers",
-    "test:jest": "node ./test/run_jest_tests.js --config ./test/jest.config.js"
+    "test:jest": "node ./test/run_jest_tests.js --config ./test/jest.config.js",
+    "test:api": "node ../../scripts/functional_tests --config ./test/api.config.js"
   },
   "devDependencies": {
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",

--- a/public/app/index.tsx
+++ b/public/app/index.tsx
@@ -35,7 +35,7 @@ import { DragDropEditor } from './../components/dragDropEditor';
 import { JsonEditor } from './../components/jsonEditor';
 
 export const App = ({ basename, notifications, http, navigation, methods }) => {
-  const metadashboard = methods.getMetadashboard()?.metadashboard;
+  const menu = methods.getMenu()?.menu;
 
   const renderToast = (error) => {
     if (error) {
@@ -55,11 +55,7 @@ export const App = ({ basename, notifications, http, navigation, methods }) => {
       content: (
         <Fragment>
           <EuiSpacer />
-          <DragDropEditor
-            renderToast={renderToast}
-            http={http}
-            value={metadashboard}
-          />
+          <DragDropEditor renderToast={renderToast} http={http} value={menu} />
         </Fragment>
       ),
     },
@@ -72,7 +68,7 @@ export const App = ({ basename, notifications, http, navigation, methods }) => {
           <JsonEditor
             renderToast={renderToast}
             http={http}
-            value={methods.getMetadashboard()}
+            value={methods.getMenu()}
           />
         </Fragment>
       ),

--- a/public/components/dragDropEditor.tsx
+++ b/public/components/dragDropEditor.tsx
@@ -32,35 +32,35 @@ import { DraggableMenuItem } from './draggableMenuItem';
 import { API_PREFIX } from '../../common';
 
 export const DragDropEditor = ({ value, http, renderToast }) => {
-  const [metadashboard, setMetadashboard] = useState(value || []);
+  const [menu, setMenu] = useState(value || []);
   const [showModal, setShowModal] = useState(false);
   const [editableItem, setEditableItem] = useState();
 
-  const openModal = (item, index = metadashboard.length + 1) => {
+  const openModal = (item, index = menu.length + 1) => {
     setShowModal(true);
     setEditableItem({ ...item, index });
   };
 
   const saveItem = (item) => {
-    const copy = [...metadashboard];
+    const copy = [...menu];
     copy.splice(editableItem.index, 1, item);
-    setMetadashboard(copy);
+    setMenu(copy);
   };
 
   const removeItem = (parentIndex, index) => {
-    const copy = [...metadashboard];
+    const copy = [...menu];
     if (index !== undefined) {
       copy[parentIndex].dashboards.splice(index, 1);
     } else {
       copy.splice(parentIndex, 1);
     }
-    setMetadashboard(copy);
+    setMenu(copy);
   };
 
   const onSave = async () => {
     try {
-      const body = JSON.stringify({ metadashboard });
-      const response = await http.put(`${API_PREFIX}/metadashboard`, {
+      const body = JSON.stringify({ menu });
+      const response = await http.put(`${API_PREFIX}/menu`, {
         body,
       });
       renderToast();
@@ -71,7 +71,7 @@ export const DragDropEditor = ({ value, http, renderToast }) => {
   };
 
   const onDragEnd = ({ source, destination }) => {
-    const copy = [...metadashboard];
+    const copy = [...menu];
     if (source && destination) {
       if (source.droppableId === 'parent') {
         const item = copy.splice(source.index, 1);
@@ -87,7 +87,7 @@ export const DragDropEditor = ({ value, http, renderToast }) => {
           item[0]
         );
       }
-      setMetadashboard(copy);
+      setMenu(copy);
     }
   };
 
@@ -126,7 +126,7 @@ export const DragDropEditor = ({ value, http, renderToast }) => {
             overflowY: 'auto',
           }}
         >
-          {metadashboard.map((dashboard, index) => (
+          {menu.map((dashboard, index) => (
             <EuiDraggable
               key={index}
               index={index}
@@ -163,10 +163,10 @@ export const DragDropEditor = ({ value, http, renderToast }) => {
                       </EuiFlexGroup>
                     </EuiFlexItem>
                   </EuiFlexGroup>
-                  {metadashboard[index].dashboards && (
+                  {menu[index].dashboards && (
                     <EuiDroppable droppableId={index.toString()} spacing="none">
                       <EuiSpacer size="s" />
-                      {metadashboard[index].dashboards.map(({ name }, idx) => (
+                      {menu[index].dashboards.map(({ name }, idx) => (
                         <DraggableMenuItem
                           name={name}
                           key={idx}

--- a/public/components/dragDropEditor.tsx
+++ b/public/components/dragDropEditor.tsx
@@ -29,6 +29,7 @@ import {
 } from '@elastic/eui';
 import { FormModal } from './formModal';
 import { DraggableMenuItem } from './draggableMenuItem';
+import { API_PREFIX } from '../../common';
 
 export const DragDropEditor = ({ value, http, renderToast }) => {
   const [metadashboard, setMetadashboard] = useState(value || []);
@@ -59,7 +60,7 @@ export const DragDropEditor = ({ value, http, renderToast }) => {
   const onSave = async () => {
     try {
       const body = JSON.stringify({ metadashboard });
-      const response = await http.put('/api/dashboards/metadashboard/edit', {
+      const response = await http.put(`${API_PREFIX}/metadashboard`, {
         body,
       });
       renderToast();

--- a/public/components/formModal.tsx
+++ b/public/components/formModal.tsx
@@ -34,6 +34,7 @@ import {
   EuiButtonIcon,
   EuiComboBox,
 } from '@elastic/eui';
+import { API_PREFIX } from '../../common';
 
 export const FormModal = ({ showModal, saveItem, item, http }) => {
   const initialValues = {
@@ -94,7 +95,7 @@ export const FormModal = ({ showModal, saveItem, item, http }) => {
   useEffect(() => {
     async function fetchDashboards() {
       try {
-        const response = await http.put('/api/dashboards/search');
+        const response = await http.put(`${API_PREFIX}/search/dashboards`);
 
         const result = response.hits.map((hit) => {
           return {

--- a/public/components/jsonEditor.tsx
+++ b/public/components/jsonEditor.tsx
@@ -33,7 +33,7 @@ export const JsonEditor = ({ http, renderToast, value }) => {
   const [errors, setErrors] = useState([]);
 
   const placeholderJson = {
-    metadashboard: [
+    menu: [
       {
         name: 'Panel name',
         type: 'entry',
@@ -42,10 +42,10 @@ export const JsonEditor = ({ http, renderToast, value }) => {
     ],
   };
 
-  const metadashboard = value || placeholderJson;
+  const menu = value || placeholderJson;
 
   const setInitialValue = () => {
-    setJsonValue(JSON.stringify(metadashboard, null, 2));
+    setJsonValue(JSON.stringify(menu, null, 2));
     setErrors([]);
   };
 
@@ -61,7 +61,7 @@ export const JsonEditor = ({ http, renderToast, value }) => {
 
   const onSave = async () => {
     try {
-      const response = await http.put(`${API_PREFIX}/metadashboard`, {
+      const response = await http.put(`${API_PREFIX}/menu`, {
         body: jsonValue,
       });
       renderToast();
@@ -81,7 +81,7 @@ export const JsonEditor = ({ http, renderToast, value }) => {
   }, [errors]);
 
   useEffect(() => {
-    const oldValue = JSON.stringify(metadashboard, null, 2);
+    const oldValue = JSON.stringify(menu, null, 2);
     setIsChanged(oldValue !== jsonValue);
   }, [jsonValue]);
 

--- a/public/components/jsonEditor.tsx
+++ b/public/components/jsonEditor.tsx
@@ -24,6 +24,7 @@ import {
   EuiFormRow,
   EuiSpacer,
 } from '@elastic/eui';
+import { API_PREFIX } from '../../common';
 
 export const JsonEditor = ({ http, renderToast, value }) => {
   const [jsonValue, setJsonValue] = useState(JSON.stringify({}));
@@ -60,7 +61,7 @@ export const JsonEditor = ({ http, renderToast, value }) => {
 
   const onSave = async () => {
     try {
-      const response = await http.put('/api/dashboards/metadashboard/edit', {
+      const response = await http.put(`${API_PREFIX}/metadashboard`, {
         body: jsonValue,
       });
       renderToast();

--- a/public/components/menu.tsx
+++ b/public/components/menu.tsx
@@ -19,18 +19,18 @@ import { Link } from './link.tsx';
 import { Dropdown } from './dropdown.tsx';
 
 export const Menu = (props) => {
-  const [metadashboard, setMetadashboard] = useState(props.metadashboard);
+  const [menu, setMenu] = useState(props.menu);
   const { baseURL, history } = props;
 
   function setActiveLink() {
-    let updated = metadashboard;
+    let updated = menu;
 
     if (history.location.hash.includes('#/view/')) {
       const currentDashboard = history.location.hash
         .split('#/view/')[1]
         .split('?')[0];
 
-      updated = metadashboard.map((dashboard) => {
+      updated = menu.map((dashboard) => {
         if (dashboard.type === 'entry') {
           return Object.assign(dashboard, {
             isActive: currentDashboard === dashboard.dashboard_id,
@@ -43,12 +43,12 @@ export const Menu = (props) => {
         });
       });
     } else {
-      updated = metadashboard.map((dashboard) =>
+      updated = menu.map((dashboard) =>
         Object.assign(dashboard, { isActive: false })
       );
     }
 
-    setMetadashboard(updated);
+    setMenu(updated);
   }
 
   useEffect(() => {
@@ -56,8 +56,8 @@ export const Menu = (props) => {
     setActiveLink();
 
     // Add class to parent container
-    const menu = document.querySelector('.bitergia-menu');
-    const parent = menu.closest('.euiHeaderSectionItem').parentElement;
+    const menuBar = document.querySelector('.bitergia-menu');
+    const parent = menuBar.closest('.euiHeaderSectionItem').parentElement;
     parent.classList.add('bitergia-menu-parent');
   }, []);
 
@@ -69,7 +69,7 @@ export const Menu = (props) => {
 
   return (
     <EuiHeaderLinks gutterSize="xs" className="bitergia-menu">
-      {metadashboard.map((link, index) =>
+      {menu.map((link, index) =>
         link.type === 'entry' ? (
           <Link item={link} baseURL={baseURL} key={index} />
         ) : (

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -20,7 +20,7 @@ import ReactDOM from 'react-dom';
 import { createBrowserHistory } from 'history';
 import { EuiHeaderLink } from '@elastic/eui';
 import { Menu } from './components/menu.tsx';
-import { PLUGIN_NAME } from '../common';
+import { PLUGIN_NAME, API_PREFIX } from '../common';
 import { AppPluginStartDependencies } from './types';
 import {
   AppMountParameters,
@@ -84,7 +84,7 @@ export class BitergiaAnalyticsPlugin
     // Fetch and add metadashboard to header
     try {
       /* eslint no-var: */
-      var response = await core.http.fetch('/api/dashboards/getmetadashboard');
+      var response = await core.http.fetch(`${API_PREFIX}/metadashboard`);
       const menuItems = JSON.parse(JSON.stringify(response.data.metadashboard));
 
       if (Array.isArray(menuItems)) {

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -81,11 +81,11 @@ export class BitergiaAnalyticsPlugin
       order: 1,
     });
 
-    // Fetch and add metadashboard to header
+    // Fetch and add menu to header
     try {
       /* eslint no-var: */
-      var response = await core.http.fetch(`${API_PREFIX}/metadashboard`);
-      const menuItems = JSON.parse(JSON.stringify(response.data.metadashboard));
+      var response = await core.http.fetch(`${API_PREFIX}/menu`);
+      const menuItems = JSON.parse(JSON.stringify(response.data.menu));
 
       if (Array.isArray(menuItems)) {
         core.chrome.navControls.registerCenter({
@@ -93,7 +93,7 @@ export class BitergiaAnalyticsPlugin
           mount: (target) => this.mountMenu(menuItems, baseURL, target),
         });
       } else {
-        console.error('Error loading menu: invalid metadashboard data');
+        console.error('Error loading menu: invalid menu data');
       }
     } catch (error) {
       console.log(error);
@@ -103,7 +103,7 @@ export class BitergiaAnalyticsPlugin
 
     // Methods available at core.getStartServices()
     return {
-      getMetadashboard: () => {
+      getMenu: () => {
         return response?.data;
       },
     };
@@ -111,16 +111,12 @@ export class BitergiaAnalyticsPlugin
 
   public stop() {}
 
-  private mountMenu(metadashboard, baseURL, targetDomElement) {
+  private mountMenu(menu, baseURL, targetDomElement) {
     // Initialize router history to know which route is active
     const history = createBrowserHistory();
 
     ReactDOM.render(
-      <Menu
-        metadashboard={metadashboard}
-        baseURL={baseURL}
-        history={history}
-      />,
+      <Menu menu={menu} baseURL={baseURL} history={history} />,
       targetDomElement
     );
     return () => ReactDOM.unmountComponentAtNode(targetDomElement);

--- a/public/tests/menu.test.tsx
+++ b/public/tests/menu.test.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { historyMock, metadashboardMock } from '../../test/mocks';
+import { historyMock, menuMock } from '../../test/mocks';
 import { Menu } from '../components/menu';
 import { EuiHeaderSectionItem } from '@elastic/eui';
 
@@ -24,10 +24,7 @@ describe('<Menu />', () => {
   it('Renders the component', () => {
     const { container } = render(
       <EuiHeaderSectionItem>
-        <Menu
-          metadashboard={metadashboardMock.metadashboard}
-          history={historyMock}
-        />
+        <Menu menu={menuMock.menu} history={historyMock} />
       </EuiHeaderSectionItem>
     );
 
@@ -39,10 +36,7 @@ describe('<Menu />', () => {
   it('Sets the current URL as active', () => {
     const { container } = render(
       <EuiHeaderSectionItem>
-        <Menu
-          metadashboard={metadashboardMock.metadashboard}
-          history={historyMock}
-        />
+        <Menu menu={menuMock.menu} history={historyMock} />
       </EuiHeaderSectionItem>
     );
     const activeLink = container.querySelector('.euiHeaderLink-isActive');

--- a/public/tests/plugin.test.ts
+++ b/public/tests/plugin.test.ts
@@ -17,7 +17,7 @@ import '@testing-library/jest-dom';
 import { BitergiaAnalyticsPlugin } from '../plugin';
 import { renderApp } from '../application';
 import {
-  metadashboardMock,
+  menuMock,
   initializerContextMock,
   coreServicesMock,
   mountParamsMock,
@@ -25,14 +25,14 @@ import {
 import { API_PREFIX } from '../../common';
 
 describe('Plugin setup', () => {
-  const apiURL = `${API_PREFIX}/metadashboard`;
+  const apiURL = `${API_PREFIX}/menu`;
   const plugin = new BitergiaAnalyticsPlugin(initializerContextMock);
 
   it('Registers menu', async () => {
     const core = await plugin.start(coreServicesMock);
 
     expect(coreServicesMock.http.fetch).toHaveBeenCalledWith(apiURL);
-    expect(core.getMetadashboard()).toEqual(metadashboardMock);
+    expect(core.getMenu()).toEqual(menuMock);
 
     // Two calls to register project name and menu
     expect(
@@ -40,13 +40,13 @@ describe('Plugin setup', () => {
     ).toHaveBeenCalledTimes(2);
   });
 
-  it('Does not register menu if metadashboard data is invalid', async () => {
+  it('Does not register menu if data is invalid', async () => {
     // Spy console logs
     console.error = jest.fn();
 
     // Return invalid value
     coreServicesMock.http.fetch = jest.fn().mockReturnValue({
-      data: { metadashboard: null },
+      data: { menu: null },
     });
 
     const core = await plugin.start(coreServicesMock);
@@ -57,9 +57,9 @@ describe('Plugin setup', () => {
       coreServicesMock.chrome.navControls.registerCenter
     ).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
-      'Error loading menu: invalid metadashboard data'
+      'Error loading menu: invalid menu data'
     );
-    expect(core.getMetadashboard()).toEqual({ metadashboard: null });
+    expect(core.getMenu()).toEqual({ menu: null });
   });
 
   it('Mounts and unmounts app', async () => {

--- a/public/tests/plugin.test.ts
+++ b/public/tests/plugin.test.ts
@@ -22,9 +22,10 @@ import {
   coreServicesMock,
   mountParamsMock,
 } from '../../test/mocks';
+import { API_PREFIX } from '../../common';
 
 describe('Plugin setup', () => {
-  const apiURL = '/api/dashboards/getmetadashboard';
+  const apiURL = `${API_PREFIX}/metadashboard`;
   const plugin = new BitergiaAnalyticsPlugin(initializerContextMock);
 
   it('Registers menu', async () => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,11 +14,11 @@
  * permissions and limitations under the License.
  */
 
-import { registerMetadashboardRoutes } from './metadashboard';
+import { registerMenuRoutes } from './menu';
 import { registerSearchRoutes } from './search';
 import { IRouter } from '../../../../src/core/server';
 
 export function defineRoutes(router: IRouter) {
-  registerMetadashboardRoutes(router);
+  registerMenuRoutes(router);
   registerSearchRoutes(router);
 }

--- a/server/routes/menu.ts
+++ b/server/routes/menu.ts
@@ -21,8 +21,8 @@ import {
 } from '../../../../src/core/server';
 import { API_PREFIX } from '../../common';
 
-const metadashboardSchema = schema.object({
-  metadashboard: schema.arrayOf(
+const menuSchema = schema.object({
+  menu: schema.arrayOf(
     schema.object({
       name: schema.string(),
       type: schema.oneOf([schema.literal('menu'), schema.literal('entry')]),
@@ -74,10 +74,10 @@ const customErrorMessage = (error) => {
   return newError;
 };
 
-export const registerMetadashboardRoutes = function (router: IRouter) {
+export const registerMenuRoutes = function (router: IRouter) {
   router.get(
     {
-      path: `${API_PREFIX}/metadashboard`,
+      path: `${API_PREFIX}/menu`,
       validate: {},
     },
     async (
@@ -90,7 +90,7 @@ export const registerMetadashboardRoutes = function (router: IRouter) {
           'get',
           {
             index: '.kibana',
-            id: 'metadashboard',
+            id: 'menu',
           }
         );
 
@@ -121,7 +121,7 @@ export const registerMetadashboardRoutes = function (router: IRouter) {
   router.put(
     {
       authRequired: true,
-      path: `${API_PREFIX}/metadashboard`,
+      path: `${API_PREFIX}/menu`,
       validate: {
         body: schema.any(),
       },
@@ -132,7 +132,7 @@ export const registerMetadashboardRoutes = function (router: IRouter) {
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
       try {
-        metadashboardSchema.validate(request.body);
+        menuSchema.validate(request.body);
       } catch (error) {
         return response.badRequest({
           body: customErrorMessage(error),
@@ -149,7 +149,7 @@ export const registerMetadashboardRoutes = function (router: IRouter) {
 
         const result = await requestClient.index({
           index: '.kibana',
-          id: 'metadashboard',
+          id: 'menu',
           body: request.body,
         });
 

--- a/server/routes/metadashboard.ts
+++ b/server/routes/metadashboard.ts
@@ -26,7 +26,12 @@ const metadashboardSchema = schema.object({
     schema.object({
       name: schema.string(),
       type: schema.oneOf([schema.literal('menu'), schema.literal('entry')]),
-      dashboard_id: schema.maybe(schema.string()),
+      dashboard_id: schema.conditional(
+        schema.siblingRef('type'),
+        'entry',
+        schema.string(),
+        schema.never()
+      ),
       description: schema.maybe(schema.string()),
       title: schema.maybe(schema.string()),
       dashboards: schema.maybe(
@@ -72,7 +77,7 @@ const customErrorMessage = (error) => {
 export const registerMetadashboardRoutes = function (router: IRouter) {
   router.get(
     {
-      path: `${API_PREFIX}/getmetadashboard`,
+      path: `${API_PREFIX}/metadashboard`,
       validate: {},
     },
     async (
@@ -116,7 +121,7 @@ export const registerMetadashboardRoutes = function (router: IRouter) {
   router.put(
     {
       authRequired: true,
-      path: `${API_PREFIX}/metadashboard/edit`,
+      path: `${API_PREFIX}/metadashboard`,
       validate: {
         body: schema.any(),
       },

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -25,7 +25,7 @@ import { API_PREFIX } from '../../common';
 export const registerSearchRoutes = function (router: IRouter) {
   router.put(
     {
-      path: `${API_PREFIX}/search`,
+      path: `${API_PREFIX}/search/dashboards`,
       validate: {
         body: schema.any(),
       },

--- a/test/api.config.js
+++ b/test/api.config.js
@@ -1,0 +1,25 @@
+import { opensearchDashboardsServerTestUser } from '@osd/test';
+import { services } from '../../../test/api_integration/services';
+
+export default async function ({ readConfigFile }) {
+  const functionalConfig = await readConfigFile(require.resolve('../../../test/functional/config'));
+
+  return {
+    testFiles: [require.resolve('./api/index.js')],
+    services,
+    servers: functionalConfig.get('servers'),
+    junit: {
+      enabled: false
+    },
+    opensearchTestCluster: functionalConfig.get('opensearchTestCluster'),
+    osdTestServer: {
+      ...functionalConfig.get('osdTestServer'),
+      serverArgs: [
+        ...functionalConfig.get('osdTestServer.serverArgs'),
+        '--opensearch.healthCheck.delay=3600000',
+        '--server.xsrf.disableProtection=true',
+        '--server.compression.referrerWhitelist=["some-host.com"]',
+      ],
+    },
+  };
+};

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021-2022 Bitergia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import expect from '@osd/expect';
+
+export default function ({ getService }) {
+  const supertest = getService('supertest');
+
+  describe('/metadashboard', () => {
+    it('PUT should return 200', async () => {
+      const response = await supertest
+        .put(`/_plugins/_bap/metadashboard`)
+        .send({
+          metadashboard: [
+            {
+              name: 'Name',
+              type: 'entry',
+              dashboard_id: 'id',
+            },
+          ],
+        })
+        .expect(200);
+    });
+
+    it('PUT fails if entry lacks dashboard_id', async () => {
+      const response = await supertest
+        .put(`/_plugins/_bap/metadashboard`)
+        .send({
+          metadashboard: [
+            {
+              name: 'Name',
+              type: 'entry',
+            },
+          ],
+        })
+        .expect(400);
+
+      expect(response.body.message).to.be(
+        '[metadashboard.0] missing field "dashboard_id"'
+      );
+    });
+
+    it('PUT fails if entry lacks name', async () => {
+      const response = await supertest
+        .put(`/_plugins/_bap/metadashboard`)
+        .send({
+          metadashboard: [
+            {
+              type: 'entry',
+              dashboard_id: 'id',
+            },
+          ],
+        })
+        .expect(400);
+
+      expect(response.body.message).to.be(
+        '[metadashboard.0] missing field "name"'
+      );
+    });
+
+    it('PUT fails if entry lacks type', async () => {
+      const response = await supertest
+        .put(`/_plugins/_bap/metadashboard`)
+        .send({
+          metadashboard: [
+            {
+              name: 'Name',
+              dashboard_id: 'id',
+            },
+          ],
+        })
+        .expect(400);
+
+      expect(response.body.message).to.be(
+        '[metadashboard.0] missing field "type"'
+      );
+    });
+
+    it('PUT fails if type is invalid', async () => {
+      const response = await supertest
+        .put(`/_plugins/_bap/metadashboard`)
+        .send({
+          metadashboard: [
+            {
+              name: 'Name',
+              dashboard_id: 'id',
+              type: 'wrong type',
+            },
+          ],
+        })
+        .expect(400);
+
+      expect(response.body.message).to.contain(
+        '[metadashboard.0.type]: types that failed validation'
+      );
+    });
+
+    it('PUT fails if key is invalid', async () => {
+      const response = await supertest
+        .put(`/_plugins/_bap/metadashboard`)
+        .send({
+          metadashboard: [
+            {
+              name: 'Name',
+              dashboard_id: 'id',
+              type: 'entry',
+              invalid: true,
+            },
+          ],
+        })
+        .expect(400);
+
+      expect(response.body.message).to.be(
+        'wrong key "invalid" at [metadashboard.0]'
+      );
+    });
+
+    it('GET should return 200', async () => {
+      const response = await supertest
+        .get(`/_plugins/_bap/metadashboard`)
+        .expect(200);
+
+      expect(response.body).to.have.property('data');
+      expect(response.body.data).to.have.property('metadashboard');
+    });
+  });
+}

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -18,12 +18,12 @@ import expect from '@osd/expect';
 export default function ({ getService }) {
   const supertest = getService('supertest');
 
-  describe('/metadashboard', () => {
+  describe('/menu', () => {
     it('PUT should return 200', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/metadashboard`)
+        .put(`/_plugins/_bap/menu`)
         .send({
-          metadashboard: [
+          menu: [
             {
               name: 'Name',
               type: 'entry',
@@ -36,9 +36,9 @@ export default function ({ getService }) {
 
     it('PUT fails if entry lacks dashboard_id', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/metadashboard`)
+        .put(`/_plugins/_bap/menu`)
         .send({
-          metadashboard: [
+          menu: [
             {
               name: 'Name',
               type: 'entry',
@@ -48,15 +48,15 @@ export default function ({ getService }) {
         .expect(400);
 
       expect(response.body.message).to.be(
-        '[metadashboard.0] missing field "dashboard_id"'
+        '[menu.0] missing field "dashboard_id"'
       );
     });
 
     it('PUT fails if entry lacks name', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/metadashboard`)
+        .put(`/_plugins/_bap/menu`)
         .send({
-          metadashboard: [
+          menu: [
             {
               type: 'entry',
               dashboard_id: 'id',
@@ -66,15 +66,15 @@ export default function ({ getService }) {
         .expect(400);
 
       expect(response.body.message).to.be(
-        '[metadashboard.0] missing field "name"'
+        '[menu.0] missing field "name"'
       );
     });
 
     it('PUT fails if entry lacks type', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/metadashboard`)
+        .put(`/_plugins/_bap/menu`)
         .send({
-          metadashboard: [
+          menu: [
             {
               name: 'Name',
               dashboard_id: 'id',
@@ -84,15 +84,15 @@ export default function ({ getService }) {
         .expect(400);
 
       expect(response.body.message).to.be(
-        '[metadashboard.0] missing field "type"'
+        '[menu.0] missing field "type"'
       );
     });
 
     it('PUT fails if type is invalid', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/metadashboard`)
+        .put(`/_plugins/_bap/menu`)
         .send({
-          metadashboard: [
+          menu: [
             {
               name: 'Name',
               dashboard_id: 'id',
@@ -103,15 +103,15 @@ export default function ({ getService }) {
         .expect(400);
 
       expect(response.body.message).to.contain(
-        '[metadashboard.0.type]: types that failed validation'
+        '[menu.0.type]: types that failed validation'
       );
     });
 
     it('PUT fails if key is invalid', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/metadashboard`)
+        .put(`/_plugins/_bap/menu`)
         .send({
-          metadashboard: [
+          menu: [
             {
               name: 'Name',
               dashboard_id: 'id',
@@ -123,17 +123,17 @@ export default function ({ getService }) {
         .expect(400);
 
       expect(response.body.message).to.be(
-        'wrong key "invalid" at [metadashboard.0]'
+        'wrong key "invalid" at [menu.0]'
       );
     });
 
     it('GET should return 200', async () => {
       const response = await supertest
-        .get(`/_plugins/_bap/metadashboard`)
+        .get(`/_plugins/_bap/menu`)
         .expect(200);
 
       expect(response.body).to.have.property('data');
-      expect(response.body.data).to.have.property('metadashboard');
+      expect(response.body.data).to.have.property('menu');
     });
   });
 }

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -15,8 +15,8 @@
 
 import { coreMock } from '../../../src/core/public/mocks';
 
-const metadashboardMock = {
-  metadashboard: [
+const menuMock = {
+  menu: [
     {
       name: 'Overview',
       dashboard_id: 'Overview',
@@ -63,7 +63,7 @@ const coreServicesMock = {
   },
   http: {
     fetch: jest.fn().mockResolvedValue({
-      data: metadashboardMock,
+      data: menuMock,
     }),
     put: jest.fn().mockResolvedValue({
       hits: [
@@ -90,7 +90,7 @@ const historyMock = {
 };
 
 export {
-  metadashboardMock,
+  menuMock,
   initializerContextMock,
   coreServicesMock,
   mountParamsMock,


### PR DESCRIPTION
- Unifies the routes to import and export the menu data into a single one with a GET and a PUT method:  `/_plugins/_bap/metadashboard`.
- Updates the README.
- Adds tests for the API. The tests can be run with `yarn test:api`.
- Adds a GitHub action that runs the tests.