### PR TITLE
Fix API base URL

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -16,4 +16,4 @@
 export const PLUGIN_ID = 'bitergiaAnalytics';
 export const PLUGIN_NAME = 'bitergia_analytics';
 
-export const API_PREFIX = '/_plugins/_bap';
+export const API_PREFIX = '/api/_bap';

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -21,7 +21,7 @@ export default function ({ getService }) {
   describe('/menu', () => {
     it('PUT should return 200', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/menu`)
+        .put(`/api/_bap/menu`)
         .send({
           menu: [
             {
@@ -36,7 +36,7 @@ export default function ({ getService }) {
 
     it('PUT fails if entry lacks dashboard_id', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/menu`)
+        .put(`/api/_bap/menu`)
         .send({
           menu: [
             {
@@ -54,7 +54,7 @@ export default function ({ getService }) {
 
     it('PUT fails if entry lacks name', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/menu`)
+        .put(`/api/_bap/menu`)
         .send({
           menu: [
             {
@@ -72,7 +72,7 @@ export default function ({ getService }) {
 
     it('PUT fails if entry lacks type', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/menu`)
+        .put(`/api/_bap/menu`)
         .send({
           menu: [
             {
@@ -90,7 +90,7 @@ export default function ({ getService }) {
 
     it('PUT fails if type is invalid', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/menu`)
+        .put(`/api/_bap/menu`)
         .send({
           menu: [
             {
@@ -109,7 +109,7 @@ export default function ({ getService }) {
 
     it('PUT fails if key is invalid', async () => {
       const response = await supertest
-        .put(`/_plugins/_bap/menu`)
+        .put(`/api/_bap/menu`)
         .send({
           menu: [
             {
@@ -129,7 +129,7 @@ export default function ({ getService }) {
 
     it('GET should return 200', async () => {
       const response = await supertest
-        .get(`/_plugins/_bap/menu`)
+        .get(`/api/_bap/menu`)
         .expect(200);
 
       expect(response.body).to.have.property('data');


### PR DESCRIPTION
Replaces `/_plugins/` with `/api/` in the API URLs so that they use each tenant's index instead of the global one.
